### PR TITLE
enhancement: Refactor log entry exception handling and update formatter/test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -483,3 +483,5 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 src/SampleApi/logs.json
+project-context.json
+vision.md

--- a/src/DotnetObserve.Core/Models/LogEntry.cs
+++ b/src/DotnetObserve.Core/Models/LogEntry.cs
@@ -31,9 +31,9 @@ public class LogEntry
     public string Source { get; set; } = "App";
 
     /// <summary>
-    /// Optional exception message or stack trace.
+    /// Optional exception object for structured error details.
     /// </summary>
-    public string? Exception { get; set; }
+    public Exception? Exception { get; set; }
 
     /// <summary>
     /// Optional correlation ID to link related log entries and traces.

--- a/tests/DotnetObserve.Tests/DotnetObserve.Tests.csproj
+++ b/tests/DotnetObserve.Tests/DotnetObserve.Tests.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotnetObserve.Core\DotnetObserve.Core.csproj" />
     <ProjectReference Include="..\..\src\DotnetObserve.Middleware\DotnetObserve.Middleware.csproj" />
+    <ProjectReference Include="..\..\src\DotnetObserve.Cli\DotnetObserve.Cli.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/DotnetObserve.Tests/LogFormatterTests.cs
+++ b/tests/DotnetObserve.Tests/LogFormatterTests.cs
@@ -1,0 +1,83 @@
+using DotnetObserve.Core.Models;
+using DotnetObserve.Cli.Utils;
+using FluentAssertions;
+using Xunit;
+
+namespace DotnetObserve.Cli.Tests;
+
+public class LogFormatterTests
+{
+    [Fact]
+    public void Format_ShouldRenderBasicLogEntry_WithEmojiAndColors()
+    {
+        var entry = new LogEntry
+        {
+            Timestamp = new DateTime(2025, 6, 18, 12, 0, 0, DateTimeKind.Utc),
+            Level = "Info",
+            Message = "Application started",
+            Source = "CLI"
+        };
+
+        var result = LogFormatter.Format(entry);
+
+        result.Should().Contain("ℹ️");
+        result.Should().Contain("[green]Info[/]");
+        result.Should().Contain("Application started");
+        result.Should().Contain("Source: [teal]CLI[/]");
+    }
+
+    [Fact]
+    public void Format_ShouldIncludeContextFields_AndHighlightStandardOnes()
+    {
+        var entry = new LogEntry
+        {
+            Message = "User login",
+            Context = new Dictionary<string, object?>
+            {
+                ["Path"] = "/login",
+                ["StatusCode"] = 200,
+                ["DurationMs"] = 123,
+                ["UserId"] = 42
+            }
+        };
+
+        var result = LogFormatter.Format(entry);
+
+        result.Should().Contain("Path: [white]/login[/]");
+        result.Should().Contain("Status: [white]200[/]");
+        result.Should().Contain("Duration: [white]123ms[/]");
+        result.Should().Contain("UserId");
+    }
+
+    [Fact]
+    public void Format_ShouldIncludeExceptionDetails()
+    {
+        var entry = new LogEntry
+        {
+            Level = "Error",
+            Message = "Unhandled exception",
+            Exception = new InvalidOperationException("Invalid operation")
+        };
+
+        var result = LogFormatter.Format(entry);
+
+        result.Should().Contain("❌");
+        result.Should().Contain("Unhandled exception");
+        result.Should().Contain("InvalidOperationException");
+        result.Should().Contain("Invalid operation");
+    }
+
+    [Fact]
+    public void Format_ShouldIncludeCorrelationId_WhenPresent()
+    {
+        var entry = new LogEntry
+        {
+            Message = "Processed request",
+            CorrelationId = "trace-abc-123"
+        };
+
+        var result = LogFormatter.Format(entry);
+
+        result.Should().Contain("CorrelationId: [white]trace-abc-123[/]");
+    }
+}

--- a/tests/DotnetObserve.Tests/ObservabilityMiddlewareTests.cs
+++ b/tests/DotnetObserve.Tests/ObservabilityMiddlewareTests.cs
@@ -2,6 +2,7 @@ using DotnetObserve.Core.Storage;
 using DotnetObserve.Core.Models;
 using Microsoft.AspNetCore.Http;
 using DotnetObserve.Middleware;
+using FluentAssertions; // ✅ Added for assertion chaining
 
 public class ObservabilityMiddlewareTests
 {
@@ -108,10 +109,11 @@ public class ObservabilityMiddlewareTests
         Assert.Equal("/fail", log.Context!["Path"]);
         Assert.Equal("GET", log.Context["Method"]);
 
-        // Enriched exception details
-        Assert.Equal("InvalidOperationException", log.Context["ExceptionType"]);
-        Assert.Contains("Something broke", log.Context["ExceptionMessage"]?.ToString());
-        Assert.NotNull(log.Context["StackTrace"]);
+        log.Exception.Should().NotBeNull();
+        log.Exception!.GetType().Name.Should().Be("InvalidOperationException");
+        log.Exception!.Message.Should().Contain("Something broke");
+
+        // If context still includes exception details (adjust as needed)
         Assert.NotNull(log.Context["ExceptionLocation"]);
     }
 }


### PR DESCRIPTION
This PR updates the LogEntry model to support structured Exception objects instead of serialized strings.
The ObservabilityMiddleware has been refactored to log exceptions properly while preserving full stack trace data.

Test Updates

- Updated ObservabilityMiddlewareTests to assert on typed exception fields (GetType().Name, Message)
- Fixed formatter test to account for Spectre.Console color markup

Other Changes

- Stopwatch timing now captured consistently via finally block
- Middleware preserves context values and rethrows errors after logging