### PR TITLE
feat: Add CLI log filtering by level, timestamp, keyword, and JSON output options

### DIFF
--- a/src/DotnetObserve.Cli/Utils/LogFilter.cs
+++ b/src/DotnetObserve.Cli/Utils/LogFilter.cs
@@ -22,12 +22,24 @@ namespace DotnetObserve.Cli.Utils
             string? contains = null)
         {
             return logs.Where(log =>
-                (string.IsNullOrWhiteSpace(level) || log.Level?.Equals(level, StringComparison.OrdinalIgnoreCase) == true) &&
-                (!since.HasValue || log.Timestamp >= since.Value) &&
-                (string.IsNullOrWhiteSpace(contains) ||
-                    log.Message.Contains(contains, StringComparison.OrdinalIgnoreCase) ||
-                    log.Context?.Any(kv => kv.Value?.ToString()?.Contains(contains, StringComparison.OrdinalIgnoreCase) == true) == true));
+            {
+                // Case-insensitive level match
+                var levelMatch = string.IsNullOrWhiteSpace(level)
+                    || log.Level?.Equals(level, StringComparison.OrdinalIgnoreCase) == true;
+
+                // Timestamp comparison
+                var sinceMatch = !since.HasValue
+                    || log.Timestamp >= since.Value;
+
+                // Message or context keyword search
+                var containsMatch = string.IsNullOrWhiteSpace(contains)
+                    || (log.Message?.Contains(contains, StringComparison.OrdinalIgnoreCase) == true)
+                    || (log.Context?.Any(kv => kv.Value?.ToString()?.Contains(contains, StringComparison.OrdinalIgnoreCase) == true) == true);
+
+                return levelMatch && sinceMatch && containsMatch;
+            });
         }
+
 
     }
 }


### PR DESCRIPTION
## Overview

This PR finalizes the CLI filtering and output experience for `dotnet-observe`. Users can now filter logs using options such as:

- `--level` (e.g. Info, Warn, Error)
- `--since` (timestamp filtering)
- `--contains` (keyword search in message or context)
- `--json` (pretty or compact)
- `--page-size` (simple paging support)

---

## Enhancements

- Added flexible filter logic in `LogFilter.Apply(...)` for message/context search
- Validated `--json` mode and `--level` input with friendly error messages
- Normalized log level casing for filtering accuracy
- Guarded invalid options with early exits

---

## Notes

This completes the CLI feature track for the MVP. Future enhancements may include:

- Saved filter presets
- Real-time tailing (file watcher)
- Inline query DSL (e.g. `level=Error && contains="sql"`)
