### PR TITLE
fix: Fix JSON serialization error by excluding raw Exception from Log Entry model

### DIFF
--- a/src/DotnetObserve.Core/Models/LogEntry.cs
+++ b/src/DotnetObserve.Core/Models/LogEntry.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace DotnetObserve.Core.Models;
 
 /// <summary>
@@ -33,7 +35,11 @@ public class LogEntry
     /// <summary>
     /// Optional exception object for structured error details.
     /// </summary>
+    [JsonIgnore]
     public Exception? Exception { get; set; }
+
+    [JsonPropertyName("ExceptionMessage")]
+    public string? ExceptionMessage => Exception?.Message;
 
     /// <summary>
     /// Optional correlation ID to link related log entries and traces.

--- a/src/SampleApi/Program.cs
+++ b/src/SampleApi/Program.cs
@@ -11,9 +11,9 @@ builder.Services.AddSingleton<IStore<LogEntry>>(
 
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
-
 app.UseMiddleware<ObservabilityMiddleware>();
+
+app.MapGet("/", () => "Hello World!");
 
 app.MapGet("/hello", () => "Hello from SampleApi!");
 


### PR DESCRIPTION
## Overview

This PR resolves a runtime crash caused by attempting to serialize `System.Exception` objects directly into JSON via `System.Text.Json`.

## Root Cause

The `.Exception` property in `LogEntry` was changed to type `Exception?` for structured error handling, but `System.Text.Json` cannot serialize complex runtime types like `TargetSite`, `StackTrace`, or `InnerException`.

## Fix

- Marked `Exception` with `[JsonIgnore]` to avoid serializing raw exception objects
- Introduced a derived `ExceptionMessage` property for JSON output
- Logging middleware and CLI continue to access `Exception` in-memory for testability and formatting

## Result

- `/throw` endpoint now logs structured exception info to `logs.json`
- No more `JsonException` or `MethodBase` serialization errors

✅ Issue resolved and middleware logging restored.