### PR TITLE
Improve CLI log readability and JSON formatting

### DIFF
--- a/src/DotnetObserve.Cli/Commands/TailCommandbuilder.cs
+++ b/src/DotnetObserve.Cli/Commands/TailCommandbuilder.cs
@@ -1,0 +1,63 @@
+using System.CommandLine;
+
+namespace DotnetObserve.Cli.Commands
+{
+    /// <summary>
+    /// Provides the builder method for the 'tail' CLI command.
+    /// Responsible for setting up options and linking to the handler logic.
+    /// </summary>
+    public static class TailCommandBuilder
+    {
+        /// <summary>
+        /// Builds the 'tail' command with all supported options and sets its handler.
+        /// </summary>
+        /// <returns>The constructed <see cref="Command"/> instance for 'tail'.</returns>
+        public static Command Build()
+        {
+            var cmd = new Command("tail", "Tail and display recent log entries");
+
+            var take = new Option<int?>(
+                ["--take", "-n"],
+                description: "How many log entries to show",
+                getDefaultValue: () => 50
+            );
+
+            var level = new Option<string>(
+                ["--level", "-l"],
+                description: "Filter by log level (e.g., Info, Warn, Error)"
+            );
+
+            var json = new Option<string>(
+                "--json",
+                description: "Output log entries in JSON format. Options: 'pretty' or 'compact'"
+            );
+
+            var since = new Option<DateTimeOffset?>(
+                "--since",
+                description: "Only include logs after this UTC timestamp (e.g. 2025-06-17T08:00:00Z)"
+            );
+
+            var contains = new Option<string>(
+                "--contains",
+                description: "Only show logs that contain this keyword in the message"
+            );
+
+            var pageSize = new Option<int>(
+                ["--page-size"],
+                description: "How many logs to show per page (0 = no paging)",
+                getDefaultValue: () => 20
+);
+
+            cmd.AddOption(take);
+            cmd.AddOption(level);
+            cmd.AddOption(json);
+            cmd.AddOption(since);
+            cmd.AddOption(contains);
+            cmd.AddOption(pageSize);
+
+            cmd.SetHandler(TailRunner.Execute, take, level, json, since, contains, pageSize);
+
+            return cmd;
+        }
+    }
+}

--- a/src/DotnetObserve.Cli/Services/TailRunner.cs
+++ b/src/DotnetObserve.Cli/Services/TailRunner.cs
@@ -1,0 +1,48 @@
+using DotnetObserve.Core.Models;
+using DotnetObserve.Core.Storage;
+using DotnetObserve.Cli.Utils;
+using Spectre.Console;
+
+namespace DotnetObserve.Cli.Commands
+{
+    /// <summary>
+    /// Executes the logic for the 'tail' command.
+    /// Loads, filters, and displays recent log entries from the log store.
+    /// </summary>
+    public static class TailRunner
+    {
+        /// <summary>
+        /// Executes the 'tail' command with the provided options.
+        /// </summary>
+        /// <param name="take">Maximum number of log entries to display.</param>
+        /// <param name="level">Log level filter (Info, Warn, Error, etc.).</param>
+        /// <param name="json">Output format: 'pretty' or 'compact'.</param>
+        /// <param name="since">Only include logs after this timestamp.</param>
+        /// <param name="contains">Filter logs containing this keyword.</param>
+        public static async Task Execute(int? take, string level, string json, DateTimeOffset? since, string contains, int pageSize)
+        {
+            var logPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../SampleApi/logs.json"));
+            if (!File.Exists(logPath))
+            {
+                AnsiConsole.MarkupLine("[red]❌ Log file not found![/]");
+                return;
+            }
+
+            var logStore = new JsonFileStore<LogEntry>(logPath);
+            var logs = await logStore.ReadAllAsync();
+
+            logs = LogFilter.Apply(logs, level, since, contains)
+                .OrderByDescending(log => log.Timestamp)
+                .Take(take ?? 50)
+                .ToList();
+
+            if (logs.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]⚠️ No log entries matched the filter criteria.[/]");
+                return;
+            }
+
+            LogPager.Display(logs, pageSize, jsonMode: json);
+        }
+    }
+}

--- a/src/DotnetObserve.Cli/Utils/LogFilter.cs
+++ b/src/DotnetObserve.Cli/Utils/LogFilter.cs
@@ -5,15 +5,15 @@ namespace DotnetObserve.Cli.Utils
     /// <summary>
     /// Provides filtering logic for collections of <see cref="LogEntry"/> objects based on log level, time, and other criteria.
     /// </summary>
-    public class LogFilter
+    public static class LogFilter
     {
         /// <summary>
-        /// Applies filter criteria to a list of logs, such as log level and minimum timestamp.
+        /// Applies filter criteria to a list of logs, such as log level, timestamp, and keyword matching.
         /// </summary>
         /// <param name="logs">The collection of log entries to filter.</param>
         /// <param name="level">Optional log level to filter by (e.g., "Error", "Info").</param>
         /// <param name="since">Optional timestamp. Only logs with a timestamp after this value will be returned.</param>
-        /// <param name="contains">Optional search. Only show logs that contain this keyword in message or context</param>
+        /// <param name="contains">Optional search keyword. Only logs that contain this keyword in the message or context will be returned.</param>
         /// <returns>A filtered enumerable of <see cref="LogEntry"/> objects.</returns>
         public static IEnumerable<LogEntry> Apply(
             IEnumerable<LogEntry> logs,
@@ -23,15 +23,12 @@ namespace DotnetObserve.Cli.Utils
         {
             return logs.Where(log =>
             {
-                // Case-insensitive level match
                 var levelMatch = string.IsNullOrWhiteSpace(level)
                     || log.Level?.Equals(level, StringComparison.OrdinalIgnoreCase) == true;
 
-                // Timestamp comparison
                 var sinceMatch = !since.HasValue
                     || log.Timestamp >= since.Value;
 
-                // Message or context keyword search
                 var containsMatch = string.IsNullOrWhiteSpace(contains)
                     || (log.Message?.Contains(contains, StringComparison.OrdinalIgnoreCase) == true)
                     || (log.Context?.Any(kv => kv.Value?.ToString()?.Contains(contains, StringComparison.OrdinalIgnoreCase) == true) == true);
@@ -39,7 +36,5 @@ namespace DotnetObserve.Cli.Utils
                 return levelMatch && sinceMatch && containsMatch;
             });
         }
-
-
     }
 }

--- a/src/DotnetObserve.Cli/Utils/LogFormatter.cs
+++ b/src/DotnetObserve.Cli/Utils/LogFormatter.cs
@@ -5,10 +5,20 @@ using Spectre.Console;
 
 namespace DotnetObserve.Cli.Utils;
 
+/// <summary>
+/// Provides methods to convert <see cref="LogEntry"/> objects into formatted strings
+/// for terminal display, either with Spectre.Console markup or plain text fallback.
+/// </summary>
 public static class LogFormatter
 {
+    /// <summary>
+    /// Formats a <see cref="LogEntry"/> with ANSI color and Spectre markup for rich terminal output.
+    /// </summary>
+    /// <param name="log">The log entry to format.</param>
+    /// <returns>A markup-formatted string ready for Spectre.Console rendering.</returns>
     public static string Format(LogEntry log)
     {
+        // Map log level to color and emoji
         var color = LogLevelStyles.GetColor(log.Level);
         var emoji = log.Level switch
         {
@@ -22,63 +32,91 @@ public static class LogFormatter
 
         var sb = new StringBuilder();
 
+        // Escape markup-sensitive strings to avoid rendering issues
         var levelEscaped = Markup.Escape(log.Level ?? "");
         var messageEscaped = Markup.Escape(log.Message ?? "");
         var sourceEscaped = Markup.Escape(log.Source ?? "");
 
-        sb.Append($"{emoji} [grey]{log.Timestamp:yyyy-MM-dd HH:mm:ss}[/] ");
-        sb.Append($"[{color}]{levelEscaped}[/] ");
-        sb.Append($"{messageEscaped}");
+        // Header: emoji + timestamp + log level
+        sb.AppendLine($"{emoji} [grey]{log.Timestamp:yyyy-MM-dd HH:mm:ss}[/] [{color}]{levelEscaped}[/]");
 
+        // Log message
+        sb.AppendLine($"[bold green3_1]Message:[/] {messageEscaped}");
+
+        // Optional source field
         if (!string.IsNullOrWhiteSpace(log.Source))
         {
-            sb.Append($" (Source: [teal]{sourceEscaped}[/])");
+            sb.AppendLine($"[yellow2]Source:[/] [white]{sourceEscaped}[/]");
         }
 
-        sb.AppendLine();
-
+        // Optional correlation ID
         if (!string.IsNullOrWhiteSpace(log.CorrelationId))
         {
-            sb.AppendLine($"  ↳ CorrelationId: [white]{Markup.Escape(log.CorrelationId)}[/]");
+            sb.AppendLine($"[cyan]CorrelationId:[/] [white]{Markup.Escape(log.CorrelationId)}[/]");
         }
 
+        // Request metadata: Path, StatusCode, DurationMs
         if (log.Context is { Count: > 0 })
         {
             var path = Markup.Escape(log.Context.TryGetValue("Path", out var p) ? p?.ToString() ?? "N/A" : "N/A");
             var status = Markup.Escape(log.Context.TryGetValue("StatusCode", out var s) ? s?.ToString() ?? "N/A" : "N/A");
             var duration = Markup.Escape(log.Context.TryGetValue("DurationMs", out var d) ? d?.ToString() ?? "N/A" : "N/A");
 
-            sb.AppendLine($"  ↳ Path: [white]{path}[/] | Status: [white]{status}[/] | Duration: [white]{duration}ms[/]");
-
-            foreach (var kvp in log.Context)
-            {
-                if (kvp.Key is "Path" or "StatusCode" or "DurationMs") continue;
-
-                var k = Markup.Escape(kvp.Key ?? "");
-                var v = Markup.Escape(kvp.Value?.ToString() ?? "");
-                sb.AppendLine($"  ↳ [silver]{k}[/]: [white]{v}[/]");
-            }
+            sb.AppendLine($"[green]Path:[/] [white]{path}[/] | [green]Status:[/] [white]{status}[/] | [green]Duration:[/] [white]{duration}ms[/]");
         }
 
+        // Special styling for ExceptionType and ExceptionLocation (if present in context)
+        if (log.Context?.TryGetValue("ExceptionType", out var exType) == true)
+        {
+            var typeText = Markup.Escape(exType?.ToString() ?? "");
+            sb.AppendLine($"[red]ExceptionType:[/] [white]{typeText}[/]");
+        }
+
+        if (log.Context?.TryGetValue("ExceptionLocation", out var exLoc) == true)
+        {
+            var locText = Markup.Escape(exLoc?.ToString() ?? "");
+            sb.AppendLine($"[dim]ExceptionLocation:[/] [white]{locText}[/]");
+        }
+
+        // Render all remaining context values not already handled
+        foreach (var kvp in log.Context ?? Enumerable.Empty<KeyValuePair<string, object?>>())
+        {
+            if (kvp.Key is "Path" or "StatusCode" or "DurationMs" or "ExceptionType" or "ExceptionLocation")
+                continue;
+
+            var k = Markup.Escape(kvp.Key ?? "");
+            var v = Markup.Escape(kvp.Value?.ToString() ?? "");
+            sb.AppendLine($"  [silver]{k}:[/] [white]{v}[/]");
+        }
+
+        // Fallback for unhandled Exception object (non-context-based)
         if (log.Exception is not null)
         {
             var exMessage = Markup.Escape(log.Exception.Message ?? "");
             var exStack = Markup.Escape(log.Exception.StackTrace?.Split('\n').FirstOrDefault()?.Trim() ?? "[no stack trace]");
 
-            sb.AppendLine($"  ⚠ [red]{log.Exception.GetType().Name}: {exMessage}[/]");
-            sb.AppendLine($"    [dim]{exStack}[/]");
+            sb.AppendLine($"[red]ExceptionType:[/] [white]{log.Exception.GetType().Name}[/] - [white]{exMessage}[/]");
+            sb.AppendLine($"[dim]ExceptionLocation:[/] [white]{exStack}[/]");
         }
 
         return sb.ToString().TrimEnd();
     }
 
+    /// <summary>
+    /// Formats a <see cref="LogEntry"/> as plain text for non-color terminals or log file output.
+    /// </summary>
+    /// <param name="log">The log entry to format.</param>
+    /// <returns>A simple, human-readable string representation of the log.</returns>
     public static string FormatPlainText(LogEntry log)
     {
+        // Timestamp and uppercase log level
         var timeStamp = log.Timestamp.ToString("yyyy-MM-dd HH:mm:ss");
         var level = log.Level?.ToUpperInvariant() ?? "INFO";
 
+        // Start with main log line
         var output = $"[{timeStamp}] [{level}] {log.Message}";
 
+        // Optional source
         if (!string.IsNullOrWhiteSpace(log.Source))
         {
             output += $" (Source: {log.Source})";
@@ -86,11 +124,13 @@ public static class LogFormatter
 
         output += "\n";
 
+        // Optional correlation ID
         if (!string.IsNullOrWhiteSpace(log.CorrelationId))
         {
             output += $"  ↳ CorrelationId: {log.CorrelationId}\n";
         }
 
+        // Structured context metadata
         if (log.Context is { Count: > 0 })
         {
             var path = log.Context.TryGetValue("Path", out var p) ? p?.ToString() : "N/A";
@@ -99,6 +139,7 @@ public static class LogFormatter
 
             output += $"  ↳ Path: {path} | Status: {status} | Duration: {duration}ms\n";
 
+            // Remaining context values
             foreach (var kvp in log.Context)
             {
                 if (kvp.Key is "Path" or "StatusCode" or "DurationMs")
@@ -108,6 +149,7 @@ public static class LogFormatter
             }
         }
 
+        // Append exception details if present
         if (log.Exception is not null)
         {
             output += $"  ⚠ Exception: {log.Exception.GetType().Name}: {log.Exception.Message}\n";

--- a/src/DotnetObserve.Cli/Utils/LogPrinter.cs
+++ b/src/DotnetObserve.Cli/Utils/LogPrinter.cs
@@ -1,0 +1,39 @@
+using DotnetObserve.Core.Models;
+using Spectre.Console;
+
+namespace DotnetObserve.Cli.Utils
+{
+    /// <summary>
+    /// Provides methods for rendering log entries in a stylized plain-text format using Spectre.Console.
+    /// </summary>
+    public static class LogPrinter
+    {
+        /// <summary>
+        /// Prints a single <see cref="LogEntry"/> to the console in a human-readable format.
+        /// </summary>
+        /// <param name="log">The log entry to display.</param>
+        public static void Print(LogEntry log)
+        {
+            var formatted = LogFormatter.Format(log);
+
+            try
+            {
+                foreach (var line in formatted.Split('\n'))
+                {
+                    AnsiConsole.MarkupLine(line.TrimEnd());
+                }
+
+                AnsiConsole.WriteLine(); 
+                AnsiConsole.Write(new Rule().RuleStyle("grey"));
+                AnsiConsole.WriteLine(); 
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]❌ Markup error: {Markup.Escape(ex.Message)}[/]");
+                Console.WriteLine(LogFormatter.FormatPlainText(log));
+            }
+        }
+
+
+    }
+}

--- a/src/DotnetObserve.Cli/Utils/LogPrinter.cs
+++ b/src/DotnetObserve.Cli/Utils/LogPrinter.cs
@@ -23,9 +23,9 @@ namespace DotnetObserve.Cli.Utils
                     AnsiConsole.MarkupLine(line.TrimEnd());
                 }
 
-                AnsiConsole.WriteLine(); 
+                AnsiConsole.WriteLine();
                 AnsiConsole.Write(new Rule().RuleStyle("grey"));
-                AnsiConsole.WriteLine(); 
+                AnsiConsole.WriteLine();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR introduces a series of enhancements to improve log readability, CLI usability, and JSON presentation:

✨ Visual & Structural Improvements

- Styled each log entry with spacing and rule dividers for better separation
- Colored exception type and location using Spectre markup
- Introduced aligned key-value formatting in --json pretty mode

🔧 Bug Fixes

- Fixed crash in Spectre rendering due to unbalanced markup
- Ensured --page-size works correctly with --take
- Enforced UTC timestamps for time filtering with --since

🧼 Code Maintenance

- Refactored and documented LogPrinter, LogPager, and LogFormatter
- Introduced helper for trimming and formatting exception file paths

This lays the foundation for future additions like metrics analysis and request replay. Everything renders cleanly and is now ready for testing and public feedback.